### PR TITLE
系统更新：修复检查不到更新

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1190,7 +1190,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>csr-active-config</key>
-				<data>5wsAAA==</data>
+				<data>5wMAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>
@@ -1207,6 +1207,7 @@
 			<key>7C436110-AB2A-4BBB-A880-FE41995C9F82</key>
 			<array>
 				<string>boot-args</string>
+				<string>csr-active-config</string>
 			</array>
 		</dict>
 		<key>LegacyEnable</key>


### PR DESCRIPTION
@WangRicky 
使用 OpenCore 禁用 SIP 是完全不同的，具体来说，除非在该节下明确告知，否则 NVRAM 变量不会被覆盖。因此，如果您已经通过 OpenCore 或 macOS 设置过一次 SIP，则必须覆盖变量：Delete
![image](https://user-images.githubusercontent.com/40148554/117627620-efc2a680-b1aa-11eb-8f37-7f167e823310.png)
